### PR TITLE
use kodak pixpro as 4k

### DIFF
--- a/launch/include/kodak_pixpro.launch
+++ b/launch/include/kodak_pixpro.launch
@@ -3,13 +3,13 @@
   <include file="$(find video_stream_opencv)/launch/camera.launch" >
     <arg name="camera_name" value="$(arg camera_name)" />
     <arg name="video_stream_provider" value="/dev/kodak-head" />
-    <arg name="fps" value="15" />
+    <arg name="fps" value="5" />
     <arg name="frame_id" value="$(arg camera_name)_optical_frame" />
     <arg name="camera_info_url" value="" />
     <arg name="flip_horizontal" value="false" />
     <arg name="flip_vertical" value="false" />
-    <arg name="width" value="1440"/>
-    <arg name="height" value="1440" />
+    <arg name="width" value="2880"/>
+    <arg name="height" value="2880" />
     <arg name="visualize" value="false" />
     <arg name="buffer_queue_size" value="1" />
   </include>


### PR DESCRIPTION
cc. @ishiguroJSK 

FYI:
with `v4l-utils >1.10.0`, we can get all these images below. (kodak 4k pro)
now we can use 4K camera

```
$ v4l2-ctl --device /dev/video8 --list-formats-ext
ioctl: VIDIOC_ENUM_FMT
	Index       : 0
	Type        : Video Capture
	Pixel Format: 'MJPG' (compressed)
	Name        : Motion-JPEG
		Size: Discrete 3840x2160
			Interval: Discrete 0.200s (5.000 fps)
		Size: Discrete 2880x2880
			Interval: Discrete 0.200s (5.000 fps)
		Size: Discrete 2048x2048
			Interval: Discrete 0.200s (5.000 fps)
		Size: Discrete 1440x1440
			Interval: Discrete 0.067s (15.000 fps)
			Interval: Discrete 0.200s (5.000 fps)
		Size: Discrete 1920x1080
			Interval: Discrete 0.067s (15.000 fps)
			Interval: Discrete 0.200s (5.000 fps)
		Size: Discrete 1280x720
			Interval: Discrete 0.033s (30.000 fps)
			Interval: Discrete 0.067s (15.000 fps)
			Interval: Discrete 0.200s (5.000 fps)
		Size: Discrete 640x360
			Interval: Discrete 0.033s (30.000 fps)
			Interval: Discrete 0.067s (15.000 fps)
			Interval: Discrete 0.200s (5.000 fps)
```

https://git.linuxtv.org/v4l-utils.git/commit/?h=stable-1.10&id=b7da4eeb863d9c1523e1d590e1019848dbb81448