### PR TITLE
Add eus_vive to fc.rosinstall

### DIFF
--- a/fc.rosinstall
+++ b/fc.rosinstall
@@ -18,6 +18,10 @@
 #     local-name: jsk-ros-pkg/jsk_robot
 #     uri: https://github.com/jsk-ros-pkg/jsk_robot.git
 #     version: master
+- git:
+    local-name: knorth55/eus_vive
+    uri: https://github.com/knorth55/eus_vive.git
+    version: master
 # need latest version
 - git:
     local-name: jsk-ros-pkg/jsk_visualization


### PR DESCRIPTION
Following [the build instructions in the README](https://github.com/knorth55/eus_vive#ros-workspace-build ), `eus_vive` itself was not installed in the Workspace, so I added `eus_vive` to `fc.rosinstall`.   


cf. https://github.com/knorth55/eus_vive/commit/9048f7af5fc88faf72c61715f4e13911e732c1d1#r80232974