### PR TITLE
Add pr2_moveit_config dependency to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>video_stream_opencv</exec_depend>
   <exec_depend>vive_ros</exec_depend>
+  <exec_depend>pr2_moveit_config</exec_depend>
 
   <export>
   </export>


### PR DESCRIPTION
I followed the instructions in the README to build, but got the following error in `roslaunch eus_vive pr1040_vive.launch head:=false`.
```
Resource not found: pr2_moveit_config
```
I added the dependencies as shown in this PR, and now it runs without error.